### PR TITLE
Fix invalid dates when it is the first month of a new year

### DIFF
--- a/CyberSource/download_payment_batch_detail_report.rb
+++ b/CyberSource/download_payment_batch_detail_report.rb
@@ -3,15 +3,15 @@
 require 'cybersource_rest_client'
 require 'csv'
 require_relative '../helpers/write_to_csv'
+require_relative '../helpers/year_or_prev_year'
 require 'config'
 Config.load_and_set_settings(Config.setting_files('config', ENV['STAGE']))
 
 # class to download the PaymentbatchDetailReport from CyberSource
 class DownloadPaymentBatchDetailReport
   def main
-    d = Date.today
-    first_day = Date.new(d.year, d.month - 1, 1)
-    last_day = Date.new(d.year, d.month - 1, -1)
+    first_day = Date.new(YearOrPrev.year, Date.today.prev_month.month, 1)
+    last_day = Date.new(YearOrPrev.year, Date.today.prev_month.month, -1)
 
     (first_day..last_day).each do |date|
       report_date = date.strftime('%Y-%m-%d')

--- a/helpers/write_to_csv.rb
+++ b/helpers/write_to_csv.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../helpers/year_or_prev_year'
 require 'config'
 Config.load_and_set_settings(Config.setting_files('config', ENV['STAGE']))
 
@@ -9,7 +10,7 @@ module WriteToCsv
     return unless data
 
     d = Date.today
-    date_stamp = Date.new(d.year, d.month - 1, 1).strftime('%Y%m')
+    date_stamp = Date.new(YearOrPrev.year, d.prev_month.month, 1).strftime('%Y%m')
     f = File.new("#{Settings.output_file_path}.#{date_stamp}", 'a+')
     data.each_line.with_index do |line, index|
       f.write(line) if index > 1

--- a/helpers/year_or_prev_year.rb
+++ b/helpers/year_or_prev_year.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# module to return the current year or the previous year as needed
+module YearOrPrev
+  def self.year
+    d = Date.today
+    d.month == 1 ? d.prev_year.year : d.year
+  end
+end

--- a/spec/download_payment_batch_detail_report_spec.rb
+++ b/spec/download_payment_batch_detail_report_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require_relative '../helpers/year_or_prev_year'
 require_relative '../CyberSource/download_payment_batch_detail_report'
 
 RSpec.describe DownloadPaymentBatchDetailReport do
   let(:result) { described_class }
   let(:download_report) { File.open(File.join(Dir.pwd, 'spec', 'fixtures', 'report_file.csv')).read }
   let(:d) { Date.today }
-  let(:date_stamp) { Date.new(d.year, d.month - 1, 1).strftime('%Y%m') }
+  let(:date_stamp) { Date.new(YearOrPrev.year, d.prev_month.month, 1).strftime('%Y%m') }
   let(:file) { File.join(Dir.pwd, 'spec', 'fixtures', "report_cyberfile.#{date_stamp}") }
 
   before do


### PR DESCRIPTION
This creates a helper class to return the correct year for last month, whether it is January or any other month of the year.