### PR TITLE
Update Dependabot configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "cybersource_rest_client"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,9 @@
 name: PushImage
 
-on: push
+on:
+  push:
+    branches:
+    - '!dependabot/bundler*'
 
 permissions:
   contents: read

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,7 +3,7 @@ name: PushImage
 on:
   push:
     branches:
-    - '!dependabot/bundler*'
+    - '!dependabot*'
 
 permissions:
   contents: read


### PR DESCRIPTION
This should precent the github workflow from running when dependabot pushes PRs.

Also run dependency updates monthly instead of weekly.