### PR TITLE
Fix date column error and upgrade ruby version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: 3.2.2
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.1
+        ruby-version: 2.7.2
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1
+FROM ruby:2.7.2
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2
+FROM ruby:3.2.2
 
 USER root
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.2'
+ruby '3.2.2'
 
 gem 'cybersource_rest_client', '0.0.57'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
-ruby '2.7.1'
+ruby '2.7.2'
 
-gem 'cybersource_rest_client', '0.0.31'
+gem 'cybersource_rest_client', '0.0.57'
 
 gem "folio_client", "~> 0.15.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.3)
+    activesupport (7.2.1)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     byebug (11.1.3)
-    concurrent-ruby (1.3.1)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
@@ -34,7 +35,7 @@ GEM
     date (3.3.4)
     diff-lcs (1.5.1)
     drb (2.2.1)
-    dry-core (1.0.0)
+    dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     dry-monads (1.6.0)
@@ -43,20 +44,21 @@ GEM
       zeitwerk (~> 2.6)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    faraday (2.8.1)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
-    ffi (1.16.3)
+    faraday (2.12.0)
+      faraday-net_http (>= 2.0, < 3.4)
+      json
+      logger
+    faraday-net_http (3.3.0)
+      net-http
+    ffi (1.17.0)
     folio_client (0.15.0)
       activesupport (>= 4.2, < 8)
       dry-monads
       faraday
       marc
       zeitwerk
-    hashdiff (1.1.0)
-    i18n (1.14.5)
+    hashdiff (1.1.1)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     immutable-ruby (0.2.0)
       concurrent-ruby (~> 1.1)
@@ -68,6 +70,7 @@ GEM
     json (2.7.2)
     jwt (2.7.0)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -78,9 +81,10 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mini_mime (1.1.5)
-    minitest (5.23.1)
-    mutex_m (0.2.0)
-    net-imap (0.3.7)
+    minitest (5.25.1)
+    net-http (0.4.1)
+      uri
+    net-imap (0.4.16)
       date
       net-protocol
     net-pop (0.1.2)
@@ -89,66 +93,54 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    parallel (1.24.0)
-    parser (3.3.2.0)
+    parallel (1.26.3)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
-    public_suffix (5.0.5)
-    racc (1.8.0)
+    public_suffix (6.0.1)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     rbtree (0.4.6)
     regexp_parser (2.9.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.8)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.64.1)
+    rubocop (1.66.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.3)
+    rubocop-ast (1.32.3)
       parser (>= 3.3.1.0)
-    rubocop-capybara (2.20.0)
-      rubocop (~> 1.41)
-    rubocop-factory_bot (2.25.1)
-      rubocop (~> 1.41)
-    rubocop-performance (1.21.0)
+    rubocop-performance (1.22.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (2.29.2)
-      rubocop (~> 1.40)
-      rubocop-capybara (~> 2.17)
-      rubocop-factory_bot (~> 2.22)
-      rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.28.3)
-      rubocop (~> 1.40)
+    rubocop-rspec (3.1.0)
+      rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     scrub_rb (1.0.1)
-    set (1.0.4)
+    securerandom (0.3.1)
+    set (1.1.0)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
-    strscan (3.1.0)
     time (0.2.2)
       date
     timeout (0.4.1)
@@ -156,15 +148,14 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.9.1)
-    unicode-display_width (2.5.0)
-    webmock (3.23.1)
+    unf (0.2.0)
+    unicode-display_width (2.6.0)
+    uri (0.13.1)
+    webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.6.15)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
@@ -182,7 +173,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.2.2p53
 
 BUNDLED WITH
    2.4.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,39 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.6)
+    activesupport (7.1.3.3)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
+    bigdecimal (3.1.8)
     byebug (11.1.3)
-    concurrent-ruby (1.2.2)
-    crack (0.4.5)
+    concurrent-ruby (1.3.1)
+    connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
       rexml
-    cybersource_rest_client (0.0.31)
-      activesupport (~> 6.0, >= 6.0.3.2)
+    cybersource_rest_client (0.0.57)
+      activesupport (>= 6.0.3.2, < 8.0)
       addressable (~> 2.3, >= 2.3.0)
       interface (~> 1.0, >= 1.0.4)
+      jose (~> 1.1)
       json (~> 2.1, >= 2.1.0)
-      jwt (~> 2.1.0)
+      jwt (= 2.7.0)
+      time (~> 0.2.2)
       typhoeus (~> 1.0, >= 1.0.1)
     date (3.3.4)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
+    drb (2.2.1)
     dry-core (1.0.0)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
@@ -33,7 +43,7 @@ GEM
       zeitwerk (~> 2.6)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    faraday (2.7.12)
+    faraday (2.8.1)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -45,12 +55,18 @@ GEM
       faraday
       marc
       zeitwerk
-    hashdiff (1.0.1)
-    i18n (1.14.1)
+    hashdiff (1.1.0)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    immutable-ruby (0.2.0)
+      concurrent-ruby (~> 1.1)
+      sorted_set (~> 1.0)
     interface (1.0.5)
-    json (2.7.1)
-    jwt (2.1.0)
+    jose (1.2.0)
+      base64
+      immutable-ruby
+    json (2.7.2)
+    jwt (2.7.0)
     language_server-protocol (3.17.0.3)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
@@ -62,7 +78,8 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mini_mime (1.1.5)
-    minitest (5.20.0)
+    minitest (5.23.1)
+    mutex_m (0.2.0)
     net-imap (0.3.7)
       date
       net-protocol
@@ -70,32 +87,34 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0)
+    net-smtp (0.5.0)
       net-protocol
     parallel (1.24.0)
-    parser (3.3.0.5)
+    parser (3.3.2.0)
       ast (~> 2.4.1)
       racc
-    public_suffix (5.0.3)
-    racc (1.7.3)
+    public_suffix (5.0.5)
+    racc (1.8.0)
     rainbow (3.1.1)
-    rake (13.1.0)
-    regexp_parser (2.9.0)
-    rexml (3.2.6)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rake (13.2.1)
+    rbtree (0.4.6)
+    regexp_parser (2.9.2)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
-    rubocop (1.60.2)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    rubocop (1.64.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -103,27 +122,37 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     rubocop-capybara (2.20.0)
       rubocop (~> 1.41)
     rubocop-factory_bot (2.25.1)
       rubocop (~> 1.41)
-    rubocop-performance (1.20.2)
+    rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
-    rubocop-rspec (2.26.1)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rspec (2.29.2)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
+      rubocop-rspec_rails (~> 2.28)
+    rubocop-rspec_rails (2.28.3)
+      rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     scrub_rb (1.0.1)
+    set (1.0.4)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
+    strscan (3.1.0)
+    time (0.2.2)
+      date
     timeout (0.4.1)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -131,18 +160,18 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
-    webmock (3.19.1)
+    webmock (3.23.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.15)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
-  cybersource_rest_client (= 0.0.31)
+  cybersource_rest_client (= 0.0.57)
   folio_client (~> 0.15.0)
   mail (~> 2.8)
   rake
@@ -153,7 +182,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.2p137
 
 BUNDLED WITH
-   2.3.22
+   2.4.13

--- a/cyber_source/download_payment_batch_detail_report.rb
+++ b/cyber_source/download_payment_batch_detail_report.rb
@@ -12,12 +12,14 @@ class DownloadPaymentBatchDetailReport
 
   CONFIGURATION_DICTIONARY = {
     merchantID: 'wfgsulair',
-    runEnvironment: "cybersource.environment.#{ENV.fetch('CYBS_ENV', 'production')}",
+    runEnvironment: "api.cybersource.com",
     timeout: 3000,
     authenticationType: 'http_signature',
     enableLog: true,
     merchantKeyId: ENV.fetch('MERCHANT_KEY_ID', nil),
     merchantsecretKey: ENV.fetch('MERCHANT_SECRET_KEY', nil),
+    loggingLevel: 'DEBUG',
+    logConfiguration: {},
     logDirectory: 'log',
     logFilename: 'cybs'
   }.freeze
@@ -44,7 +46,7 @@ class DownloadPaymentBatchDetailReport
         puts report_date, status_code, headers, data
       rescue StandardError => e
         puts report_date
-        puts e.message
+        puts e.backtrace
         next
       end
       next unless data
@@ -112,8 +114,14 @@ class DownloadPaymentBatchDetailReport
   end
 
   def is_a_payment?(account, batch_date, transaction_date)
-    tx_date = Date.parse(transaction_date)
-    bx_date = Date.parse(batch_date)
+    begin
+      tx_date = Date.parse(transaction_date)
+      bx_date = Date.parse(batch_date)
+    rescue Date::Error => e
+      puts e.message
+      return false
+    end
+    
     dates = [tx_date - 1, tx_date, tx_date + 1, bx_date - 1, bx_date, bx_date + 1]
 
     (dates.include?(created_date(account)) || dates.include?(updated_date(account))) &&


### PR DESCRIPTION
Handles exception where report columns are not in the expected format.
Upgrade ruby to v3.2.2