### PR TITLE
Adjust date offsets when searching for folio account payments

### DIFF
--- a/cyber_source/download_payment_batch_detail_report.rb
+++ b/cyber_source/download_payment_batch_detail_report.rb
@@ -122,7 +122,8 @@ class DownloadPaymentBatchDetailReport
       return false
     end
     
-    dates = [tx_date - 1, tx_date, tx_date + 1, bx_date - 1, bx_date, bx_date + 1]
+    # dates = [tx_date - 1, tx_date, tx_date + 1, bx_date - 1, bx_date, bx_date + 1]
+    dates = [tx_date, bx_date - 1]
 
     (dates.include?(created_date(account)) || dates.include?(updated_date(account))) &&
       (account['paymentStatus']['name'] == 'Paid fully')


### PR DESCRIPTION
Addressing the possibility is that the date offsets are too inclusive, and if people make multiple payments within +/- 1 day of each other, then the sum of those payments will not match any of the payments reported by Cybersource as paid amounts.

Maybe I should do a code walkthrough of this so you can see what I am trying to accomplish here?